### PR TITLE
Moving rails32 into master

### DIFF
--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -10,7 +10,7 @@ module Analytical
     send :include, InstanceMethods
     send :include, Analytical::BotDetector
     helper_method :analytical
-    class_inheritable_accessor :analytical_options
+    class_attribute :analytical_options
 
     self.analytical_options = options.reverse_merge({
       :modules=>[],


### PR DESCRIPTION
Updated Master to use the most current analytical release. let's start using the master branch in prod.
